### PR TITLE
Add a gzip step for the kernel; clean up the build; fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 boot.o
 kernel
+kernel.gz
 kernel.o
 md5.o
+*.o

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 CC=gcc
-CFLAGS=-c -m32
+CFLAGS=-c -m32 -nostdlib -fno-stack-protector -fno-builtin
 OBJECT_FILES=boot.o kernel.o sha256.o
 LDFLAGS=-m elf_i386
 
-all: kernel
+all: kernel.gz
 
 %.o: %.S
 	$(CC) $(CFLAGS) $< -o $@
+
+kernel.gz: kernel
+	gzip kernel
 
 kernel: boot.o kernel.o sha256.o
 	$(LD) $(LDFLAGS) $^ -o $@
@@ -14,4 +17,4 @@ kernel: boot.o kernel.o sha256.o
 .PHONY: all clean
 
 clean:
-	rm $(OBJECT_FILES) kernel
+	rm -f $(OBJECT_FILES) kernel kernel.gz


### PR DESCRIPTION
The gzip step is needed for kexec testing.

The build cleanups are needed for more reliable building.

The .gitignore was not ignoring all .o as it should.

The Makefile would fail if the files to be removed did not exist.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>